### PR TITLE
Allow direct arrays in fromJson

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -763,6 +763,10 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function fromJson($value, $asObject = false)
     {
+        if(is_array($value)) {
+            return $value;
+        }
+        
         return json_decode($value, ! $asObject);
     }
 


### PR DESCRIPTION
I have a model that gets populated with a nested array. 'collection' attribute casts don't work when the $value isn't a json string, and throws an ErrorException: `json_decode() expects parameter 1 to be string, array given`