### PR TITLE
Add Laravel 7 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "illuminate/contracts": "^5.0|^6.0",
-        "illuminate/support": "^4.0|^5.0|^6.0"
+        "illuminate/contracts": "^5.0|^6.0|^7.0",
+        "illuminate/support": "^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "*",
-        "phpunit/phpunit": "^4.0|^5.0"
+        "phpunit/phpunit": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR updates the composer dependencies to add Laravel 7 compatibility.

@jenssegers Could you take a look at this at your earliest convenience? It would be greatly appreciated, as I have other packages depending on this to be updated so that they will work with Laravel 7 as well.

Thanks again for this package! :)