### PR TITLE
Add custom casts support.

### DIFF
--- a/src/Contracts/CastsAttributes.php
+++ b/src/Contracts/CastsAttributes.php
@@ -11,7 +11,7 @@ interface CastsAttributes
      * @param  array  $attributes
      * @return mixed
      */
-    public function get($model, string $key, $value, array $attributes);
+    public function get($model, $key, $value, $attributes);
 
     /**
      * Transform the attribute to its underlying model values.
@@ -22,5 +22,5 @@ interface CastsAttributes
      * @param  array  $attributes
      * @return array
      */
-    public function set($model, string $key, $value, array $attributes);
+    public function set($model, $key, $value, $attributes);
 }

--- a/src/Contracts/CastsAttributes.php
+++ b/src/Contracts/CastsAttributes.php
@@ -1,0 +1,26 @@
+<?php namespace Jenssegers\Model\Contracts;
+
+interface CastsAttributes
+{
+    /**
+     * Transform the attribute from the underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, string $key, $value, array $attributes);
+
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function set($model, string $key, $value, array $attributes);
+}

--- a/src/Contracts/CastsInboundAttributes.php
+++ b/src/Contracts/CastsInboundAttributes.php
@@ -11,5 +11,5 @@ interface CastsInboundAttributes
      * @param  array  $attributes
      * @return array
      */
-    public function set($model, string $key, $value, array $attributes);
+    public function set($model, $key, $value, $attributes);
 }

--- a/src/Contracts/CastsInboundAttributes.php
+++ b/src/Contracts/CastsInboundAttributes.php
@@ -1,0 +1,15 @@
+<?php namespace Jenssegers\Model\Contracts;
+
+interface CastsInboundAttributes
+{
+    /**
+     * Transform the attribute to its underlying model values.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return array
+     */
+    public function set($model, string $key, $value, array $attributes);
+}

--- a/src/Model.php
+++ b/src/Model.php
@@ -724,7 +724,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function isClassCastable($key)
     {
         return array_key_exists($key, $this->casts) &&
-                class_exists($class = $this->casts[$key]) &&
+                class_exists($class = $this->parseCasterClass($this->casts[$key])) &&
                 ! in_array($class, static::$primitiveCastTypes);
     }
 
@@ -743,6 +743,19 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $segments = explode(':', $castType, 2);
 
         return new $segments[0](...explode(',', $segments[1]));
+    }
+
+    /**
+     * Parse the given caster class, removing any arguments.
+     *
+     * @param  string  $class
+     * @return string
+     */
+    protected function parseCasterClass($class)
+    {
+        return strpos($class, ':') === false
+                        ? $class
+                        : explode(':', $class, 2)[0];
     }
 
     /**
@@ -845,7 +858,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $caster = $this->resolveCasterClass($key);
 
             return $this->classCastCache[$key] = $caster instanceof CastsInboundAttributes
-                ? $this->attributes[$key]
+                ? ($this->attributes[$key] ?? null)
                 : $caster->get($this, $key, $this->attributes[$key] ?? null, $this->attributes);
         }
     }

--- a/src/Model.php
+++ b/src/Model.php
@@ -977,7 +977,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         return $this->attributes;
     }
 
-
     /**
      * Set the array of model attributes. No checking is done.
      *

--- a/src/Model.php
+++ b/src/Model.php
@@ -4,8 +4,9 @@ use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection as BaseCollection;
+use Illuminate\Support\Str;
+use Jenssegers\Model\Contracts\CastsInboundAttributes;
 use JsonSerializable;
 
 abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializable
@@ -59,6 +60,38 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @var array
      */
     protected $casts = [];
+
+    /**
+     * The attributes that have been cast using custom classes.
+     *
+     * @var array
+     */
+    protected $classCastCache = [];
+
+    /**
+     * The built-in, primitive cast types supported by Eloquent.
+     *
+     * @var array
+     */
+    protected static $primitiveCastTypes = [
+        'array',
+        'bool',
+        'boolean',
+        'collection',
+        'custom_datetime',
+        'date',
+        'datetime',
+        'decimal',
+        'double',
+        'float',
+        'int',
+        'integer',
+        'json',
+        'object',
+        'real',
+        'string',
+        'timestamp',
+    ];
 
     /**
      * Indicates whether attributes are snake cased on arrays.
@@ -483,16 +516,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // Next we will handle any casts that have been setup for this model and cast
         // the values to their appropriate type. If the attribute has a mutator we
         // will not perform the cast on those attributes to avoid any confusion.
-        foreach ($this->casts as $key => $value) {
-            if (! array_key_exists($key, $attributes) ||
-                in_array($key, $mutatedAttributes)) {
-                continue;
-            }
-
-            $attributes[$key] = $this->castAttribute(
-                $key, $attributes[$key]
-            );
-        }
+        $attributes = $this->addCastAttributesToArray(
+            $attributes, $mutatedAttributes
+        );
 
         // Here we will grab all of the appended, calculated attributes to this model
         // as these attributes are not really in the attributes array, but are run
@@ -505,13 +531,44 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Add the casted attributes to the attributes array.
+     *
+     * @param  array  $attributes
+     * @param  array  $mutatedAttributes
+     * @return array
+     */
+    protected function addCastAttributesToArray(array $attributes, array $mutatedAttributes)
+    {
+        foreach ($this->casts as $key => $value) {
+            if (! array_key_exists($key, $attributes) ||
+                in_array($key, $mutatedAttributes) ||
+                $this->isClassCastable($key)) {
+                continue;
+            }
+
+            // Here we will cast the attribute. Then, if the cast is a date or datetime cast
+            // then we will serialize the date for the array. This will convert the dates
+            // to strings based on the date format specified for these Eloquent models.
+            $attributes[$key] = $this->castAttribute(
+                $key, $attributes[$key]
+            );
+
+            if ($attributes[$key] instanceof Arrayable) {
+                $attributes[$key] = $attributes[$key]->toArray();
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
      * Get an attribute array of all arrayable attributes.
      *
      * @return array
      */
     protected function getArrayableAttributes()
     {
-        return $this->getArrayableItems($this->attributes);
+        return $this->getArrayableItems($this->getAttributes());
     }
 
     /**
@@ -565,6 +622,11 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     protected function getAttributeValue($key)
     {
         $value = $this->getAttributeFromArray($key);
+
+        // If the attribute is castable via a class, cast it.
+        if ($this->isClassCastable($key)) {
+            return $this->getClassCastableAttributeValue($key);
+        }
 
         // If the attribute has a get mutator, we will call that then return what
         // it returns as the value, which is useful for transforming values on
@@ -658,6 +720,67 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     }
 
     /**
+     * Determine if the given key is cast using a custom class.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isClassCastable($key)
+    {
+        return array_key_exists($key, $this->casts) &&
+                class_exists($class = $this->casts[$key]) &&
+                ! in_array($class, static::$primitiveCastTypes);
+    }
+
+    /**
+     * Resolve the custom caster class for a given key.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function resolveCasterClass($key)
+    {
+        if (strpos($castType = $this->casts[$key], ':') === false) {
+            return new $castType;
+        }
+
+        $segments = explode(':', $castType, 2);
+
+        return new $segments[0](...explode(',', $segments[1]));
+    }
+
+    /**
+     * Merge the cast class attributes back into the model.
+     *
+     * @return void
+     */
+    protected function mergeAttributesFromClassCasts()
+    {
+        foreach ($this->classCastCache as $key => $value) {
+            $caster = $this->resolveCasterClass($key);
+
+            $this->attributes = array_merge(
+                $this->attributes,
+                $caster instanceof CastsInboundAttributes
+                       ? [$key => $value]
+                       : $this->normalizeCastClassResponse($key, $caster->set($this, $key, $value, $this->attributes))
+            );
+        }
+    }
+
+    /**
+     * Normalize the response from a custom class caster.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return array
+     */
+    protected function normalizeCastClassResponse($key, $value)
+    {
+        return is_array($value) ? $value : [$key => $value];
+    }
+
+    /**
      * Get the type of cast for a model attribute.
      *
      * @param  string  $key
@@ -677,11 +800,13 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function castAttribute($key, $value)
     {
-        if (is_null($value)) {
+        $castType = $this->getCastType($key);
+
+        if (is_null($value) && in_array($castType, static::$primitiveCastTypes)) {
             return $value;
         }
 
-        switch ($this->getCastType($key)) {
+        switch ($castType) {
             case 'int':
             case 'integer':
                 return (int) $value;
@@ -701,8 +826,31 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
                 return $this->fromJson($value);
             case 'collection':
                 return new BaseCollection($this->fromJson($value));
-            default:
-                return $value;
+        }
+
+        if ($this->isClassCastable($key)) {
+            return $this->getClassCastableAttributeValue($key);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Cast the given attribute using a custom cast class.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    protected function getClassCastableAttributeValue($key)
+    {
+        if (isset($this->classCastCache[$key])) {
+            return $this->classCastCache[$key];
+        } else {
+            $caster = $this->resolveCasterClass($key);
+
+            return $this->classCastCache[$key] = $caster instanceof CastsInboundAttributes
+                ? $this->attributes[$key]
+                : $caster->get($this, $key, $this->attributes[$key] ?? null, $this->attributes);
         }
     }
 
@@ -724,6 +872,12 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             return $this->{$method}($value);
         }
 
+        if ($this->isClassCastable($key)) {
+            $this->setClassCastableAttribute($key, $value);
+
+            return $this;
+        }
+
         if ($this->isJsonCastable($key) && ! is_null($value)) {
             $value = $this->asJson($value);
         }
@@ -731,6 +885,35 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         $this->attributes[$key] = $value;
 
         return $this;
+    }
+
+    /**
+     * Set the value of a class castable attribute.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    protected function setClassCastableAttribute($key, $value)
+    {
+        if (is_null($value)) {
+            $this->attributes = array_merge($this->attributes, array_map(
+                function () {
+                },
+                $this->normalizeCastClassResponse($key, $this->resolveCasterClass($key)->set(
+                    $this, $key, $this->{$key}, $this->attributes
+                ))
+            ));
+        } else {
+            $this->attributes = array_merge(
+                $this->attributes,
+                $this->normalizeCastClassResponse($key, $this->resolveCasterClass($key)->set(
+                    $this, $key, $value, $this->attributes
+                ))
+            );
+        }
+
+        unset($this->classCastCache[$key]);
     }
 
     /**
@@ -789,7 +972,25 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function getAttributes()
     {
+        $this->mergeAttributesFromClassCasts();
+
         return $this->attributes;
+    }
+
+
+    /**
+     * Set the array of model attributes. No checking is done.
+     *
+     * @param  array  $attributes
+     * @return $this
+     */
+    public function setRawAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+
+        $this->classCastCache = [];
+
+        return $this;
     }
 
     /**

--- a/src/Model.php
+++ b/src/Model.php
@@ -552,10 +552,6 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
             $attributes[$key] = $this->castAttribute(
                 $key, $attributes[$key]
             );
-
-            if ($attributes[$key] instanceof Arrayable) {
-                $attributes[$key] = $attributes[$key]->toArray();
-            }
         }
 
         return $attributes;

--- a/tests/ModelCustomCastingTest.php
+++ b/tests/ModelCustomCastingTest.php
@@ -81,6 +81,19 @@ class ModelCustomCastingTest extends TestCase
         $this->assertEquals(hash('sha256', 'secret2'), $model->password);
     }
 
+    public function testCastClassResolution()
+    {
+        $model = new TestModelWithCustomCast;
+
+        $model->other_password = 'secret';
+
+        $this->assertEquals(hash('md5', 'secret'), $model->other_password);
+
+        $model->other_password = 'secret2';
+
+        $this->assertEquals(hash('md5', 'secret2'), $model->other_password);
+    }
+
     public function testSettingRawAttributesClearsTheCastCache()
     {
         $model = new TestModelWithCustomCast;

--- a/tests/ModelCustomCastingTest.php
+++ b/tests/ModelCustomCastingTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use Jenssegers\Model\Contracts\CastsAttributes;
+use Jenssegers\Model\Contracts\CastsInboundAttributes;
+use Jenssegers\Model\Model;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group integration
+ */
+class ModelCustomCastingTest extends TestCase
+{
+    public function testBasicCustomCasting()
+    {
+        $model = new TestModelWithCustomCast;
+        $model->reversed = 'taylor';
+
+        $this->assertEquals('taylor', $model->reversed);
+        $this->assertEquals('rolyat', $model->getAttributes()['reversed']);
+        $this->assertEquals('rolyat', $model->toArray()['reversed']);
+
+        $unserializedModel = unserialize(serialize($model));
+
+        $this->assertEquals('taylor', $unserializedModel->reversed);
+        $this->assertEquals('rolyat', $unserializedModel->getAttributes()['reversed']);
+        $this->assertEquals('rolyat', $unserializedModel->toArray()['reversed']);
+
+        $model->setRawAttributes([
+            'address_line_one' => '110 Kingsbrook St.',
+            'address_line_two' => 'My House',
+        ]);
+
+        $this->assertEquals('110 Kingsbrook St.', $model->address->lineOne);
+        $this->assertEquals('My House', $model->address->lineTwo);
+
+        $this->assertEquals('110 Kingsbrook St.', $model->toArray()['address_line_one']);
+        $this->assertEquals('My House', $model->toArray()['address_line_two']);
+
+        $model->address->lineOne = '117 Spencer St.';
+
+        $this->assertFalse(isset($model->toArray()['address']));
+        $this->assertEquals('117 Spencer St.', $model->toArray()['address_line_one']);
+        $this->assertEquals('My House', $model->toArray()['address_line_two']);
+
+        $this->assertEquals('117 Spencer St.', json_decode($model->toJson(), true)['address_line_one']);
+        $this->assertEquals('My House', json_decode($model->toJson(), true)['address_line_two']);
+
+        $model->address = null;
+
+        $this->assertNull($model->toArray()['address_line_one']);
+        $this->assertNull($model->toArray()['address_line_two']);
+
+        $model->options = ['foo' => 'bar'];
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $model->options = ['foo' => 'bar'];
+        $model->options = ['foo' => 'bar'];
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+        $this->assertEquals(['foo' => 'bar'], $model->options);
+
+        $this->assertEquals(json_encode(['foo' => 'bar']), $model->getAttributes()['options']);
+    }
+
+    public function testOneWayCasting()
+    {
+        // CastsInboundAttributes is used for casting that is unidirectional... only use case I can think of is one-way hashing...
+        $model = new TestModelWithCustomCast;
+
+        $model->password = 'secret';
+
+        $this->assertEquals(hash('sha256', 'secret'), $model->password);
+        $this->assertEquals(hash('sha256', 'secret'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret'), $model->password);
+
+        $model->password = 'secret2';
+
+        $this->assertEquals(hash('sha256', 'secret2'), $model->password);
+        $this->assertEquals(hash('sha256', 'secret2'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret2'), $model->getAttributes()['password']);
+        $this->assertEquals(hash('sha256', 'secret2'), $model->password);
+    }
+
+    public function testSettingRawAttributesClearsTheCastCache()
+    {
+        $model = new TestModelWithCustomCast;
+
+        $model->setRawAttributes([
+            'address_line_one' => '110 Kingsbrook St.',
+            'address_line_two' => 'My House',
+        ]);
+
+        $this->assertEquals('110 Kingsbrook St.', $model->address->lineOne);
+
+        $model->setRawAttributes([
+            'address_line_one' => '117 Spencer St.',
+            'address_line_two' => 'My House',
+        ]);
+
+        $this->assertEquals('117 Spencer St.', $model->address->lineOne);
+    }
+}
+
+class TestModelWithCustomCast extends Model
+{
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'address' => AddressCaster::class,
+        'password' => HashCaster::class,
+        'other_password' => HashCaster::class.':md5',
+        'reversed' => ReverseCaster::class,
+        'options' => JsonCaster::class,
+    ];
+}
+
+class HashCaster implements CastsInboundAttributes
+{
+    public function __construct($algorithm = 'sha256')
+    {
+        $this->algorithm = $algorithm;
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return [$key => hash($this->algorithm, $value)];
+    }
+}
+
+class ReverseCaster implements CastsAttributes
+{
+    public function get($model, $key, $value, $attributes)
+    {
+        return strrev($value);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return [$key => strrev($value)];
+    }
+}
+
+class AddressCaster implements CastsAttributes
+{
+    public function get($model, $key, $value, $attributes)
+    {
+        return new Address($attributes['address_line_one'], $attributes['address_line_two']);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return ['address_line_one' => $value->lineOne, 'address_line_two' => $value->lineTwo];
+    }
+}
+
+class JsonCaster implements CastsAttributes
+{
+    public function get($model, $key, $value, $attributes)
+    {
+        return json_decode($value, true);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return json_encode($value);
+    }
+}
+
+class Address
+{
+    public $lineOne;
+    public $lineTwo;
+
+    public function __construct($lineOne, $lineTwo)
+    {
+        $this->lineOne = $lineOne;
+        $this->lineTwo = $lineTwo;
+    }
+}


### PR DESCRIPTION
Add custom casts support as per the [addition to Laravel 7.x](https://laravel.com/docs/7.x/releases#laravel-7).

I've had to copy the interfaces from Laravel 7 to keep backwards-compatibility within the package, which can be found under `Jenssegers/Model/Contracts`.