### PR TITLE
Make illuminate/support dependency optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         }
     ],
     "require": {
-        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0",
-        "illuminate/support": "^4.0|^5.0|^6.0|^7.0|^8.0"
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
+        "illuminate/support": "*",
         "php-coveralls/php-coveralls": "*",
         "phpunit/phpunit": "*"
     },
@@ -25,5 +25,8 @@
     },
     "autoload-dev": {
         "classmap": ["tests/stubs"]
+    },
+    "suggest": {
+        "illuminate/collections": "Required to use the collection cast."
     }
 }

--- a/src/Model.php
+++ b/src/Model.php
@@ -3,8 +3,6 @@
 use ArrayAccess;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection as BaseCollection;
 use JsonSerializable;
 
@@ -604,7 +602,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasGetMutator($key)
     {
-        return method_exists($this, 'get'.Str::studly($key).'Attribute');
+        return method_exists($this, 'get'.Util::stringStudly($key).'Attribute');
     }
 
     /**
@@ -616,7 +614,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     protected function mutateAttribute($key, $value)
     {
-        return $this->{'get'.Str::studly($key).'Attribute'}($value);
+        return $this->{'get'.Util::stringStudly($key).'Attribute'}($value);
     }
 
     /**
@@ -719,7 +717,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         // which simply lets the developers tweak the attribute as it is set on
         // the model, such as "json_encoding" an listing of data for storage.
         if ($this->hasSetMutator($key)) {
-            $method = 'set'.Str::studly($key).'Attribute';
+            $method = 'set'.Util::stringStudly($key).'Attribute';
 
             return $this->{$method}($value);
         }
@@ -741,7 +739,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      */
     public function hasSetMutator($key)
     {
-        return method_exists($this, 'set'.Str::studly($key).'Attribute');
+        return method_exists($this, 'set'.Util::stringStudly($key).'Attribute');
     }
 
     /**
@@ -777,9 +775,9 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
     {
         $except = $except ?: [];
 
-        $attributes = Arr::except($this->attributes, $except);
+        $attributes = array_diff_key($this->attributes, array_flip($except));
 
-        return with($instance = new static)->fill($attributes);
+        return (new static)->fill($attributes);
     }
 
     /**
@@ -824,7 +822,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
         if (preg_match_all('/(?<=^|;)get([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($class)), $matches)) {
             foreach ($matches[1] as $match) {
                 if (static::$snakeAttributes) {
-                    $match = Str::snake($match);
+                    $match = Util::stringSnake($match);
                 }
 
                 $mutatedAttributes[] = lcfirst($match);

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,0 +1,72 @@
+<?php namespace Jenssegers\Model;
+
+class Util
+{
+    /**
+     * The cache of snake-cased words.
+     *
+     * @var array
+     */
+    protected static $snakeCache = [];
+
+    /**
+     * The cache of studly-cased words.
+     *
+     * @var array
+     */
+    protected static $studlyCache = [];
+
+    /**
+     * Convert the given string to lower-case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function stringLower($value)
+    {
+        return mb_strtolower($value, 'UTF-8');
+    }
+
+    /**
+     * Convert a string to snake case.
+     *
+     * @param  string  $value
+     * @param  string  $delimiter
+     * @return string
+     */
+    public static function stringSnake($value, $delimiter = '_')
+    {
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key][$delimiter])) {
+            return static::$snakeCache[$key][$delimiter];
+        }
+
+        if (! ctype_lower($value)) {
+            $value = preg_replace('/\s+/u', '', ucwords($value));
+
+            $value = static::stringLower(preg_replace('/(.)(?=[A-Z])/u', '$1'.$delimiter, $value));
+        }
+
+        return static::$snakeCache[$key][$delimiter] = $value;
+    }
+
+    /**
+     * Convert a value to studly caps case.
+     *
+     * @param  string  $value
+     * @return string
+     */
+    public static function stringStudly($value)
+    {
+        $key = $value;
+
+        if (isset(static::$studlyCache[$key])) {
+            return static::$studlyCache[$key];
+        }
+
+        $value = ucwords(str_replace(['-', '_'], ' ', $value));
+
+        return static::$studlyCache[$key] = str_replace(' ', '', $value);
+    }
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Jenssegers\Model\Util;
+use PHPUnit\Framework\TestCase;
+
+class UtilTest extends TestCase
+{
+    public function testLower()
+    {
+        $this->assertSame('foo bar baz', Util::stringLower('FOO BAR BAZ'));
+        $this->assertSame('foo bar baz', Util::stringLower('fOo Bar bAz'));
+    }
+
+    public function testSnake()
+    {
+        $this->assertSame('laravel_p_h_p_framework', Util::stringSnake('LaravelPHPFramework'));
+        $this->assertSame('laravel_php_framework', Util::stringSnake('LaravelPhpFramework'));
+        $this->assertSame('laravel php framework', Util::stringSnake('LaravelPhpFramework', ' '));
+        $this->assertSame('laravel_php_framework', Util::stringSnake('Laravel Php Framework'));
+        $this->assertSame('laravel_php_framework', Util::stringSnake('Laravel    Php      Framework   '));
+        // ensure cache keys don't overlap
+        $this->assertSame('laravel__php__framework', Util::stringSnake('LaravelPhpFramework', '__'));
+        $this->assertSame('laravel_php_framework_', Util::stringSnake('LaravelPhpFramework_', '_'));
+        $this->assertSame('laravel_php_framework', Util::stringSnake('laravel php Framework'));
+        $this->assertSame('laravel_php_frame_work', Util::stringSnake('laravel php FrameWork'));
+        // prevent breaking changes
+        $this->assertSame('foo-bar', Util::stringSnake('foo-bar'));
+        $this->assertSame('foo-_bar', Util::stringSnake('Foo-Bar'));
+        $this->assertSame('foo__bar', Util::stringSnake('Foo_Bar'));
+        $this->assertSame('żółtałódka', Util::stringSnake('ŻółtaŁódka'));
+    }
+
+    public function testStudly()
+    {
+        $this->assertSame('LaravelPHPFramework', Util::stringStudly('laravel_p_h_p_framework'));
+        $this->assertSame('LaravelPhpFramework', Util::stringStudly('laravel_php_framework'));
+        $this->assertSame('LaravelPhPFramework', Util::stringStudly('laravel-phP-framework'));
+        $this->assertSame('LaravelPhpFramework', Util::stringStudly('laravel  -_-  php   -_-   framework   '));
+
+        $this->assertSame('FooBar', Util::stringStudly('fooBar'));
+        $this->assertSame('FooBar', Util::stringStudly('foo_bar'));
+        $this->assertSame('FooBar', Util::stringStudly('foo_bar')); // test cache
+        $this->assertSame('FooBarBaz', Util::stringStudly('foo-barBaz'));
+        $this->assertSame('FooBarBaz', Util::stringStudly('foo-bar_baz'));
+    }
+}


### PR DESCRIPTION
## Description

I have made the illuminate/support dependency optional by removing usage of the Arr and Str helpers. The Arr-helper method could easily be replaced with a PHP-native function and the two Str-helpers are copied from Laravel 8 as-is. The illuminate/support dependency is removed and illuminate/collections is added to the suggested packages.

## Motivation and context

It is considered bad practice to use laravel/support in a framework-agnostic package: https://mattallan.me/posts/dont-use-illuminate-support/. Laravel tries to avoid this for its sub-packages as well. This package only uses one easy to replace Arr-helper method, two Str-helper methods, a useless call to the with-helper and the collections. The Laravel collections have been released as a separate package so there is just a tiny part this library uses from illuminate/support.

It is customary in Laravel to move dependencies for features only used by a small portion of users to the suggested packages. In addition, we can no longer provide support for Laravel <8 if we add illuminate/collections to the regular dependencies. This will obviously be a breaking change for people who use this library outside Laravel and use the collections. If you don't want to release a breaking change we can look into creating a meta package that can trick Composer into installing the correct version based on your Laravel version and/or other dependencies.

## How has this been tested?

This is tested with the existing unit tests and the new tests for the string helpers are copied from Laravel.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
