### PR TITLE
Suppress deprecation notices in PHP 8.0+

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -441,6 +441,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();
@@ -863,6 +864,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  mixed  $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->$offset);
@@ -874,6 +876,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  mixed  $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->$offset;
@@ -886,6 +889,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  mixed  $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->$offset = $value;
@@ -897,6 +901,7 @@ abstract class Model implements ArrayAccess, Arrayable, Jsonable, JsonSerializab
      * @param  mixed  $offset
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->$offset);


### PR DESCRIPTION
Alternate to https://github.com/jenssegers/model/pull/42/

Suppress deprecation notices in PHP 8.0 and 8.1 from internal languages methods missing return typehints.

> PHP Deprecated:  Return type of Jenssengers\Model\Model::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in vendor/jenssegers/model/src/Model.php on line 866

Instead of adding those explicit return types (and breaking support with older PHP versions), add attribute `#[\ReturnTypeWillChange]` to the same `Illuminate\Database\Eloquent\Model` methods as "laravel/framework" 8.x  (https://github.com/laravel/framework/blob/888947cedacbefac4019a163ccf941e592edad82/src/Illuminate/Database/Eloquent/Model.php): 

* `offsetExists`
* `offsetGet`
* `offsetSet`
* `offsetUnset`
* `jsonSerialize`

---

* "laravel/framework" 9.x eventually replaces `#[\ReturnTypeWillChange]` with explicit return types for PHP 8.1+: https://github.com/laravel/framework/blob/067c21851f15512f921e899e1ec2d09d6ddff0cd/src/Illuminate/Database/Eloquent/Model.php
* PHP 9+ will require the return types: https://wiki.php.net/rfc/internal_method_return_types