### PR TITLE
Updating composer.json to support Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0"
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "jenssegers/model",
+    "name": "joshcadman01/jenssegers-model",
     "description": "An Laravel eloquent-like model class, for Laravel and other frameworks",
     "keywords": ["laravel", "eloquent", "model"],
-    "homepage": "https://github.com/jenssegers/model",
+    "homepage": "https://github.com/joshcadman01/jessengers-model",
     "license" : "MIT",
     "authors": [
         {


### PR DESCRIPTION
This PR adds support to Laravel 11 by allowing `illuminate/contracts` and `illuminate/support` to use the 11.x version.