### PR TITLE
Fix tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit.phar
 composer.lock
 .phpunit.result.cache
 .idea
+.phpunit*

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="true"
->
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -224,11 +224,11 @@ class ModelTest extends TestCase
     {
         ModelStub::unguard();
         $mock = $this->getMockBuilder('stdClass')
-            ->setMethods(['callback'])
+            ->addMethods(['callback'])
             ->getMock();
         $mock->expects($this->once())
             ->method('callback')
-            ->will($this->returnValue('foo'));
+            ->willReturn('foo');
         $string = ModelStub::unguarded([$mock, 'callback']);
         $this->assertEquals('foo', $string);
         ModelStub::reguard();


### PR DESCRIPTION
Fixes #41 
Fixes #42 

PHPUnit's mock builder's `->setMethod()` has been replaced with `->addMethod()` in PHPUnit 10. Unfortunately it is being deprecated and removed without replacement in PHPUnit 12, at which time the test will need to be written differently to accommodate for that. Further, `->getMockBuilder()` is also being deprecated.

I'm leaving the deprecated version in place, thinking it will get things moving quickly, allowing for more time and research down the road as to how the test needs to be restructured in PHPUnit 12.

https://github.com/sebastianbergmann/phpunit/issues/5320
https://github.com/sebastianbergmann/phpunit/issues/5754
https://github.com/sebastianbergmann/phpunit/issues/5755
https://github.com/sebastianbergmann/phpunit/issues/3985

PS: I believe the StyleCI issue is something that needs to be resolved within StyleCI, not sure as I don't use that service, and also do not see a specific configuration file within this repo.